### PR TITLE
Fix an error introduced to rect.union

### DIFF
--- a/lib/gamejs.js
+++ b/lib/gamejs.js
@@ -286,8 +286,8 @@ Rect.prototype.union = function(rect) {
 
    x = Math.min(this.left, rect.left);
    y = Math.min(this.top, rect.top);
-   width = Math.max(this.right, rect.right);
-   height = Math.max(this.bottom, rect.bottom);
+   width = Math.max(this.right, rect.right) - x;
+   height = Math.max(this.bottom, rect.bottom) - y;
    return new Rect(x, y, width, height);
 }
 

--- a/test/gamejs.js
+++ b/test/gamejs.js
@@ -209,7 +209,10 @@ exports.testRectUnion = function() {
 
    // overlaping
    rectTwo = new gamejs.Rect(-5, 2, 16, 15);
-   assert.deepEqual(rect.union(rectTwo), new gamejs.Rect(-5, 0, 11, 17));
+   assert.deepEqual(rect.union(rectTwo), new gamejs.Rect(-5, 0, 16, 17));
+
+   rectTwo = new gamejs.Rect(9, 9, 2, 2);
+   assert.deepEqual(rect.union(rectTwo), new gamejs.Rect(0, 0, 11, 11));
 }
 
 exports.testSurfaceConstructors = function() {


### PR DESCRIPTION
Bigger rectangles returned. (Because of my confusion of right and width attributes.)
