### PR TITLE
Bugfix for group.remove()

### DIFF
--- a/lib/gamejs/utils/arrays.js
+++ b/lib/gamejs/utils/arrays.js
@@ -5,7 +5,11 @@
  */
 
 exports.remove = function(item, array) {
-   return array.splice(array.indexOf(item), 1);
+   var index = array.indexOf(item);
+   if (index !== -1) {
+      return array.splice(array.indexOf(item), 1);
+   }
+   return [];
 };
 
 /**

--- a/tests/sprite.js
+++ b/tests/sprite.js
@@ -64,6 +64,11 @@ test('SpriteGroup', function() {
       group.remove(sp);
       ok(!group.has(sp));
    });
+   
+   // is other sprite removed if group.remove is called with invalid arg?
+   group.add(sprites[0]);
+   group.remove(sprites[1]);
+   ok(group.has(sprites[0]));
 });
 
 test('SpriteCollisions', function() {


### PR DESCRIPTION
If group.remove() is called with a sprite not in the group another sprite is removed instead. I seem to always make this mistake and the reason for the result can be quite hard do figure out.
- Bugfix for gamejs/utils/array.js
- Test case for this in tests/sprite.js
