### PR TITLE
Image load did not set _context of Surface

### DIFF
--- a/lib/gamejs/image.js
+++ b/lib/gamejs/image.js
@@ -61,6 +61,7 @@ exports.load = function(key) {
    var surface = new gamejs.Surface(img.getSize());
    // NOTE hack setting protected _canvas directly
    surface._canvas = canvas;
+   surface._context = context;
    return surface;
 };
 


### PR DESCRIPTION
The image.load function does not set _context on the newly created surface, only _canvas so then when mask.fromSurface reads the _context.getImageData().data it doesn't get the real pixel values. But plotting the surface works as that uses the _canvas...

Feel free to ignore this if you had another approach in mind when working on the Surface design.
