### PR TITLE
Enhancement for cygwin users

### DIFF
--- a/bin/minify-app.sh
+++ b/bin/minify-app.sh
@@ -18,6 +18,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if [ -z "$GAMEJS_HOME" ]; then
     source "$SCRIPT_DIR/find-gamejs-home.sh"
     GAMEJS_HOME="$(find_gamejs_home "$0")"
+
+    if [ "$OSTYPE" == 'cygwin' ]; then
+		GAMEJS_HOME=`cygpath -m ${GAMEJS_HOME}`
+	fi
 fi
 
 if [ -z "$JAVA_HOME" ] ; then

--- a/bin/minify-gamejs.sh
+++ b/bin/minify-gamejs.sh
@@ -13,6 +13,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if [ -z "$GAMEJS_HOME" ]; then
     source "$SCRIPT_DIR/find-gamejs-home.sh"
     GAMEJS_HOME="$(find_gamejs_home "$0")"
+
+    if [ "$OSTYPE" == 'cygwin' ]; then
+		GAMEJS_HOME=`cygpath -m ${GAMEJS_HOME}`
+	fi
 fi
 
 if [ -z "$JAVA_HOME" ] ; then


### PR DESCRIPTION
Hi,

The jar command fails when using cygwin. The problem is that it uses the cygwin path "/cygdrive/c/" instead of using the Windows path "C:\".

It is fixed using the command "cygpath -m ".
