### PR TITLE
Fix the pre-function comment on Sprite.prototype.kill

### DIFF
--- a/lib/gamejs/sprite.js
+++ b/lib/gamejs/sprite.js
@@ -50,7 +50,7 @@ var Sprite = exports.Sprite = function() {
 
 /**
  * Kill this sprite. This removes the sprite from all associated groups and
- * makes future calls to `Sprite.isDead()` return `false`
+ * makes future calls to `Sprite.isDead()` return `true`
  */
 Sprite.prototype.kill = function() {
    this._alive = false;


### PR DESCRIPTION
This change fixes the automatically-generated documentation on the Sprite.prototype.kill method.  Killing a sprite causes the isDead() method to return true, not false.
