### PR TITLE
Rect's 'bottomleft', 'bottomright' and 'topright' sets fixed

### DIFF
--- a/lib/gamejs.js
+++ b/lib/gamejs.js
@@ -254,7 +254,7 @@ objects.accessors(Rect.prototype, {
       set: function() {
          var args = normalizeRectArguments.apply(this, arguments);
          this.left = args.left;
-         this.bottom = args.bottom;
+         this.bottom = args.top;
          return;
       }
    },
@@ -269,7 +269,7 @@ objects.accessors(Rect.prototype, {
       },
       set: function() {
          var args = normalizeRectArguments.apply(this, arguments);
-         this.right = args.right;
+         this.right = args.left;
          this.top = args.top;
          return;
       }
@@ -285,8 +285,8 @@ objects.accessors(Rect.prototype, {
       },
       set: function() {
          var args = normalizeRectArguments.apply(this, arguments);
-         this.right = args.right;
-         this.bottom = args.bottom;
+         this.right = args.left;
+         this.bottom = args.top;
          return;
       }
    },


### PR DESCRIPTION
Hi!

I noticed a weird behaviour in my game when trying to set this.rect.bottomleft on my Sprite, so I dug up the source and noticed that the set methods used parameters from the function normalizeRectArguments() that don't exist. This lead to some of the Sprites position parameters to be set to NaN. I hope this fixed behaviour is the one that you had in mind too. Thanks!
