### PR TITLE
Build fix for cygwin users

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -30,6 +30,11 @@ else
 fi
 
 TEMP_WORKING=`mktemp -d /tmp/gamejs.XXXX`
+
+if [ "$OSTYPE" == 'cygwin' ]; then
+  TEMP_WORKING=`cygpath -m ${TEMP_WORKING}`
+fi
+
 EXEC_YABBLER="${java_cmd} -jar ${GAMEJS_HOME}/utils/rhino/js.jar ${GAMEJS_HOME}/utils/yabbler/yabbler.js"
 EXEC_CLOSURE="cat"
 OUTPUT_FILE="${GAMEJS_HOME}/gamejs.min.js"


### PR DESCRIPTION
Building gamejs on Cygwin with the java command requires windows style paths, like: C:/cygwin/home/
The temp file path was still using posix style paths, causing the build to create an empty gamejs.min.js file.
