### PR TITLE
Added splice and shift commands

### DIFF
--- a/lib/gamejs/sprite.js
+++ b/lib/gamejs/sprite.js
@@ -257,6 +257,34 @@ Group.prototype.empty = function() {
 };
 
 /**
+ * Splice the elements of the group
+ */
+Group.prototype.splice = function(indexToRemove, numberToRemove) {
+  this._sprites.splice(indexToRemove, numberToRemove);
+  return;
+};
+
+/**
+ * Shift the sprites in the group
+ * Deletes the oldest sprite in the group, useful to limit size of groups
+ */
+Group.prototype.shift = function() {
+  this._sprites.shift();
+  return;
+};
+
+
+/**
+ * @returns {Number} of sprites in the group
+ * Used hand in hand with splice method (see above)
+ */
+Group.prototype.length = function() {
+  return this._sprites.length;
+};
+
+
+
+/**
  * @returns {Array} of sprites colliding with the point
  */
 Group.prototype.collidePoint = function() {


### PR DESCRIPTION
Two commands that were pretty useful for me when I was using this library, splicing, shifting and getting the length of Sprite Groups. Pretty small addition but I feel its shift and length are pretty necessary functions when dealing with  sprite groups.
