### PR TITLE
Fix "not well-formed" error in Firefox.

### DIFF
--- a/utils/yabbler/yabble.js
+++ b/utils/yabbler/yabble.js
@@ -305,6 +305,7 @@
 
 		var xhr = this.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
 		var moduleUri = resolveModuleUri(moduleId);
+		xhr.overrideMimeType("application/json");
 		xhr.open('GET', moduleUri, true);
 		xhr.onreadystatechange = function() {
 			if (xhr.readyState === 4) {


### PR DESCRIPTION
Firefox requires the mime type to be set on the XMLHttpRequest used to
load javascript modules (see http://stackoverflow.com/a/677943/1005455),
otherwise it spits a "not well-formed" error that pollutes the console.
I'm patching Yabble directly (I could make a pull request on Yabble's repo but since it wasn't updated for 6 years, the chances for a merge are low).